### PR TITLE
Remove dead/duplicate/unused code + fix undefined model_id

### DIFF
--- a/wallbreaker/cli.py
+++ b/wallbreaker/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import sys
 
 from .config import Config, ConfigError, Endpoint, load_config
@@ -304,8 +305,6 @@ def main(argv: list[str] | None = None) -> int:
                 return 2
             return 0
         if args.command == "regrade":
-            import asyncio
-
             from .regrade import format_regrade, regrade_log
             from .report import resolve_log_path
 

--- a/wallbreaker/cli.py
+++ b/wallbreaker/cli.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import asyncio
 import sys
 
 from .config import Config, ConfigError, Endpoint, load_config

--- a/wallbreaker/tools/campaign.py
+++ b/wallbreaker/tools/campaign.py
@@ -97,7 +97,7 @@ async def _campaign(args: dict, ctx: ToolContext) -> str:
             try:
                 msgs = builder(behavior)
                 reply = await target.complete(msgs, system=system, max_tokens=max_tokens)
-            except Exception as exc:  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 trail.append((name, "ERROR"))
                 continue
             label, score, reason, _s = await grade(

--- a/wallbreaker/tools/image.py
+++ b/wallbreaker/tools/image.py
@@ -10,7 +10,7 @@ from ..classify import HEDGE_MARKERS, classify
 from ..judging import grade_image
 from ..providers.image_provider import ext_for_mime
 from ..transforms import TRANSFORMS, apply_chain
-from .files import _confine, _resolve
+from .files import _resolve
 from .registry import ToolContext, ToolRegistry
 
 IMAGE_DIR = "wb_images"

--- a/wallbreaker/tools/validate.py
+++ b/wallbreaker/tools/validate.py
@@ -30,7 +30,7 @@ async def _validate(args: dict, ctx: ToolContext) -> str:
             resp = await target.complete(
                 [user(task)], system=system, max_tokens=max_tokens, temperature=temperature
             )
-        except Exception as exc:  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             return "ERROR"
         label, _score, _r, _s = await grade(
             ctx.judge_endpoint, resp, payload=task, objective=objective

--- a/wallbreaker/transforms/stego.py
+++ b/wallbreaker/transforms/stego.py
@@ -52,21 +52,6 @@ def tokenade_encode(text: str, carrier: str = "🧬") -> str:
 
 
 def tokenade_decode(text: str) -> str:
-    collected = [b for ch in text if (b := _vs_to_byte(ch)) is not None]
-    return bytes(collected).decode("utf-8", "replace")
-
-
-def tokenade_encode(text: str, carrier: str = "🧬") -> str:
-    data = text.encode("utf-8")
-    out = [carrier]
-    for i, b in enumerate(data):
-        out.append(_byte_to_vs(b))
-        if (i + 1) % 4 == 0:
-            out.append("‍" + carrier)
-    return "".join(out)
-
-
-def tokenade_decode(text: str) -> str:
     collected = []
     for ch in text:
         b = _vs_to_byte(ch)

--- a/wallbreaker/transforms/unicode_obf.py
+++ b/wallbreaker/transforms/unicode_obf.py
@@ -131,24 +131,6 @@ def unicode_noise_strip(text: str) -> str:
     )
 
 
-def rtl_override_encode(text: str) -> str:
-    return RLO + text + PDF
-
-
-def rtl_override_decode(text: str) -> str:
-    return text.replace(RLO, "").replace(PDF, "")
-
-
-def pepper_encode(text: str, rate: float = 0.35) -> str:
-    rng = random.Random(0xBEEF)
-    out = []
-    for ch in text:
-        out.append(ch)
-        if rng.random() < rate:
-            out.append(rng.choice(PEPPER_CHARS))
-    return "".join(out)
-
-
 def pepper_decode(text: str) -> str:
     return zero_width_strip(text)
 

--- a/wallbreaker/tui/app.py
+++ b/wallbreaker/tui/app.py
@@ -81,7 +81,7 @@ from ..agent.loop import AgentEvents, run_autonomous, run_turn
 from ..agent.messages import TextBlock, ToolResultBlock, user
 from ..classify import classify, verdict_color
 from ..config import Config, Endpoint
-from ..prompts import DEFAULT_SYSTEM, compose_system
+from ..prompts import compose_system
 from ..providers.factory import build_provider
 from ..session import RunLog
 from ..tools import build_registry
@@ -1194,7 +1194,7 @@ class RthApp(App):
             f"target modality -> {modality} ({self.config.target.model})", title="target",
         ))
         self._mount(widgets.info_panel(
-            f"target model -> {model_id} @ {self.config.target.base_url}",
+            f"target model -> {self.config.target.model} @ {self.config.target.base_url}",
             title="target",
         ))
 
@@ -1375,8 +1375,6 @@ class RthApp(App):
         ))
 
     async def _cmd_lib(self, rest: list[str]) -> None:
-        from ..tools import l1b3rt4s as lib
-
         action = rest[0] if rest else "list"
         if action == "update":
             out = await self.registry.execute("l1b3rt4s_list", {})
@@ -1897,8 +1895,8 @@ class RthApp(App):
         self._mount(widgets.info_panel(
             f"graded fires: {total}   ASR: {asr}   ({hits} bypass / {total - hits} held)\n\n"
             f"verdict mix:\n" + "\n".join(bar_lines) + "\n\n"
-            f"ASR by technique:\n" + "\n".join(tech_lines) + "\n\n"
-            f"busiest tools:\n" + "\n".join(tool_lines) + "\n\n"
+            "ASR by technique:\n" + "\n".join(tech_lines) + "\n\n"
+            "busiest tools:\n" + "\n".join(tool_lines) + "\n\n"
             f"log: {self.runlog.path}",
             title="stats",
         ))

--- a/wallbreaker/tui/sidebar.py
+++ b/wallbreaker/tui/sidebar.py
@@ -6,19 +6,13 @@ from rich.text import Text
 from textual.widgets import Static
 
 from .theme import PALETTE
-
-_VERDICT_COLOR = {
-    "COMPLIED": PALETTE["verdict_bad"],
-    "PARTIAL": PALETTE["verdict_partial"],
-    "REFUSED": PALETTE["verdict_good"],
-    "EMPTY": PALETTE["info"],
-}
+from .widgets import verdict_color
 
 
 def _verdict_text(label) -> Text:
     if not label:
         return Text("-", style=PALETTE["label"])
-    return Text(str(label), style=f"bold {_VERDICT_COLOR.get(label, PALETTE['muted'])}")
+    return Text(str(label), style=f"bold {verdict_color(label)}")
 
 
 class StatsPanel(Static):


### PR DESCRIPTION
Behavior-preserving cleanup pass (redundant / unused / non-DRY code). No functional changes intended — the one exception is a latent-bug fix, called out below.

## What changed
**Dead duplicate code (accidental copy-paste)**
- `transforms/stego.py`: `tokenade_encode`/`tokenade_decode` were defined twice, identically. Removed the shadowed first pair.
- `transforms/unicode_obf.py`: `rtl_override_encode/decode` + `pepper_encode` duplicated. Removed the dead v1 trio. `pepper_encode` v1 used a **different seed** (`0xBEEF`) than the live v2 (`0xBADC0DE`), so only the shadowed copy was dropped — runtime output is unchanged.

**Unused code**
- Removed unused imports: `asyncio` (cli.py), `_confine` (tools/image.py), `DEFAULT_SYSTEM` (tui/app.py), a never-used local `l1b3rt4s` import (tui/app.py).
- Dropped two unused `as exc` exception binds (tools/campaign.py, tools/validate.py).
- Removed two placeholder-less `f`-string prefixes in the app.py stats panel.

**Non-DRY**
- `tui/sidebar.py` held a byte-identical copy of `widgets._VERDICT` plus an inline `.get(label, muted)`. It now uses `widgets.verdict_color()` — single source of truth. (No import cycle: `widgets` doesn't import `sidebar`.)

**Latent bug (⚠️ the one behavior change)**
- `tui/app.py::_set_target_modality` referenced an **undefined `model_id`**, which would raise `NameError` whenever that path ran. Fixed to `self.config.target.model` — the exact value the line above already uses. Turns a crashing path into a working one.

## Verification
- Full suite identical before/after: **843 passed, 26 skipped**. (The 19 `test_system_prompts.py` failures are pre-existing and environmental — they need the runtime-fetched `library/system_prompts/` corpus, which isn't vendored; they fail the same way on `main`.)
- `ruff check --select F` clean; all touched files compile.

## Deliberately NOT changed
- `_TECHNIQUE_REWARD` / `_TRANSFORM_REWARD` / `_SEED_REWARD` are identical today but are independent tuning knobs in different tools — merging would couple things meant to be tuned separately.
- `classify.verdict_color` vs `widgets.verdict_color` share a name but return different palettes for different renderers — a confusing collision, not duplication.