### PR TITLE
Fix: log no longer force-scrolls to bottom on every message

### DIFF
--- a/tests/test_scroll_follow.py
+++ b/tests/test_scroll_follow.py
@@ -1,0 +1,50 @@
+import asyncio
+
+from wallbreaker.config import Config, Endpoint
+
+
+def _build_app(**prefs):
+    from wallbreaker.prompts import DEFAULT_SYSTEM
+    from wallbreaker.tui.app import RthApp
+
+    base = {"log": False, "auto": True}
+    base.update(prefs)
+    ep = Endpoint("t", "openai", "http://x", "m", provider=("WandB",))
+    cfg = Config(default_profile="t", profiles={"t": ep}, target=ep)
+    return RthApp(cfg, ep, DEFAULT_SYSTEM, prefs=base)
+
+
+def test_log_follows_only_when_pinned_to_bottom():
+    """New output follows the view only while the operator is at the bottom.
+
+    Regression: previously every mount called scroll_end unconditionally, so
+    scrolling up to read was impossible — each new message yanked back down.
+    """
+
+    async def run():
+        app = _build_app()
+        async with app.run_test() as pilot:
+            for i in range(40):
+                app._mount(f"message {i}")
+            await pilot.pause()
+            log = app._log
+            assert log.max_scroll_y > 0  # content overflows the viewport
+
+            # operator scrolls up to read history
+            log.scroll_home(animate=False)
+            await pilot.pause()
+            assert log.scroll_y <= 1
+
+            # a new message arrives while scrolled up -> must NOT jump to bottom
+            app._mount("incoming while reading")
+            await pilot.pause()
+            assert log.scroll_y <= 1, f"view jumped to {log.scroll_y}"
+
+            # back at the bottom -> new messages follow again
+            log.scroll_end(animate=False)
+            await pilot.pause()
+            app._mount("incoming at bottom")
+            await pilot.pause()
+            assert log.scroll_y >= log.max_scroll_y - 2
+
+    asyncio.run(run())

--- a/wallbreaker/tui/app.py
+++ b/wallbreaker/tui/app.py
@@ -390,8 +390,9 @@ class RthApp(App):
             self._runs[rid] = state
             widget = Static(widgets.run_panel(state))
             self._run_widgets[rid] = widget
+            at_bottom = self._at_bottom()
             self._log.mount(widget)
-            self._log.scroll_end(animate=False)
+            self._follow(at_bottom)
             self._ensure_run_timer()
             return
 
@@ -435,8 +436,9 @@ class RthApp(App):
         widget = self._run_widgets.get(rid)
         state = self._runs.get(rid)
         if widget is not None and state is not None:
+            at_bottom = self._at_bottom()
             widget.update(widgets.run_panel(state))
-            self._log.scroll_end(animate=False)
+            self._follow(at_bottom)
 
     def _ensure_run_timer(self) -> None:
         if self._run_timer is None:
@@ -503,9 +505,23 @@ class RthApp(App):
             tokens=tokens,
         )
 
+    def _at_bottom(self) -> bool:
+        """True when the log is scrolled to (or within a line of) the bottom.
+
+        New output only follows the view while this holds, so once the operator
+        scrolls up to read, incoming messages stop yanking them back down.
+        """
+        return self._log.scroll_y >= self._log.max_scroll_y - 2
+
+    def _follow(self, was_at_bottom: bool) -> None:
+        """Re-pin to the bottom only if the view was already there."""
+        if was_at_bottom:
+            self._log.scroll_end(animate=False)
+
     def _mount(self, renderable) -> None:
+        at_bottom = self._at_bottom()
         self._log.mount(Static(renderable))
-        self._log.scroll_end(animate=False)
+        self._follow(at_bottom)
 
     def _ensure_assistant(self) -> None:
         if self._assistant is None:
@@ -545,6 +561,7 @@ class RthApp(App):
 
     def _submit_user(self, text: str) -> None:
         self._mount(widgets.user_panel(text))
+        self._log.scroll_end(animate=False)  # your own submit always jumps to the latest
         self.history.append(user(text))
         self._record_input(text)
         self.runlog.user(text)
@@ -747,11 +764,12 @@ class RthApp(App):
         self.query_one("#prompt", Input).focus()
 
     def _on_text(self, delta: str) -> None:
+        at_bottom = self._at_bottom()
         self._ensure_assistant()
         self._buf += delta
         assert self._assistant is not None
         self._assistant.update(widgets.assistant_panel(self._buf, self.endpoint.model))
-        self._log.scroll_end(animate=False)
+        self._follow(at_bottom)
 
     def _on_turn_end(self, message) -> None:
         self._assistant = None


### PR DESCRIPTION
## Problem
The TUI log (`#log`) called `scroll_end()` **unconditionally** on every mount and every streaming update, so scrolling up to read earlier output was impossible — each new message (and every token during streaming) yanked the view straight back to the bottom.

## Fix
Only follow the bottom when the operator is already there:
- `_at_bottom()` — is the log within a line of the bottom?
- `_follow(was_at_bottom)` — re-pin only if it was.

Captured **before** new content is added, then applied at all four scroll sites (`_mount`, `_run_start`, `_update_run`, `_on_text`/streaming). Submitting your own prompt still explicitly jumps to the latest (`_submit_user`), so your action always shows the response — only *passive* incoming output respects your scroll position.

## Test
`tests/test_scroll_follow.py` drives it through the Textual test harness: overflow the log, scroll to top, mount a new message → asserts the view **doesn't** jump; then scroll to bottom, mount → asserts it **does** follow.

## Verification
- New test passes; full suite shows no new failures (the 19 `test_system_prompts` failures are pre-existing/corpus-dependent, same as `main`).
- Isolated to `wallbreaker/tui/app.py` + the new test — independent of #1.