### PR TITLE
Load .env at CLI startup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "textual>=0.79",
     "rich>=13.7",
     "mcp>=1.0",
+    "python-dotenv>=1.0",
 ]
 
 [project.urls]

--- a/wallbreaker/cli.py
+++ b/wallbreaker/cli.py
@@ -4,6 +4,8 @@ import argparse
 import asyncio
 import sys
 
+from dotenv import load_dotenv
+
 from .config import Config, ConfigError, Endpoint, load_config
 from .providers.base import ProviderError
 
@@ -240,6 +242,7 @@ async def _one_shot(config: Config, args: argparse.Namespace) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    load_dotenv()
     raw = list(sys.argv[1:] if argv is None else argv)
     first_pos = next((a for a in raw if not a.startswith("-")), None)
 


### PR DESCRIPTION
`.env.example` is shipped but `load_dotenv()` was never called, so keys placed in `.env` were silently ignored. This loads it once in `main()` and declares `python-dotenv` as an explicit dependency (previously only transitive).