### PR TITLE
Fix ImportError crashing one-shot mode

### DIFF
--- a/wallbreaker/cli.py
+++ b/wallbreaker/cli.py
@@ -179,7 +179,7 @@ async def _one_shot(config: Config, args: argparse.Namespace) -> int:
     from .providers.factory import build_provider
     from .tools import build_registry
 
-    from ..session import RunLog
+    from .session import RunLog
 
     endpoint = resolve_endpoint(config, args)
     provider = build_provider(endpoint)


### PR DESCRIPTION
`_one_shot` imports `RunLog` via `from ..session`, which reaches beyond the top-level package and raises `ImportError: attempted relative import beyond top-level package` — crashing every one-shot (`wallbreaker "<prompt>"`) run. `session` is a sibling of `cli`, so this uses a single-dot import.