### PR TITLE
Add caesar5 and caesar13 cipher transforms

### DIFF
--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -101,6 +101,18 @@ def test_caesar3_shifts_three():
     assert t.decode(t.encode(SAMPLE)) == SAMPLE
 
 
+def test_caesar5_shifts_five():
+    t = TRANSFORMS["caesar5"]
+    assert t.encode("abc XYZ") == "fgh CDE"
+    assert t.decode(t.encode(SAMPLE)) == SAMPLE
+
+
+def test_caesar13_shifts_thirteen():
+    t = TRANSFORMS["caesar13"]
+    assert t.encode("abc XYZ") == "nop KLM"
+    assert t.decode(t.encode(SAMPLE)) == SAMPLE
+
+
 def test_anagram_scrambles_deterministically():
     t = TRANSFORMS["anagram"]
     a = t.encode("ignore")

--- a/wallbreaker/prompts.py
+++ b/wallbreaker/prompts.py
@@ -377,7 +377,7 @@ Pull a ready scaffold with preset action='get' name='godmode_hybrid' (or 'divide
 NEW TRANSFORMS (query_target transforms= / response_transforms=): variation_selector
 (invisible-byte channel, lossless), flip_fwo/flip_fcw (word/char reversal), aim (letters->
 numbers), payload_split (variable-assembly), delimiter / tokenbreak (BPE-boundary breaking),
-caesar3, anagram. Pick per the fingerprint.
+caesar3, caesar5, caesar13, anagram. Pick per the fingerprint.
 NEW PRESETS (preset action='get'): response_prime, flip_attack, past_tense, immersive_world,
 math_encode, logic_encode, cot_safety_hijack, deceptive_delight, deep_inception,
 adversarial_poetry, math_problem - plus the partial-completion set (defender_re,

--- a/wallbreaker/transforms/__init__.py
+++ b/wallbreaker/transforms/__init__.py
@@ -57,6 +57,8 @@ TRANSFORMS: dict[str, Transform] = dict(
         _t("payload_split", encodings.payload_split_encode, encodings.payload_split_decode, "Variable-assignment payload splitting + join"),
         _t("delimiter", encodings.delimiter_encode, encodings.delimiter_decode, "Dotted '.' char separator framing (folds literal dots)", lossy=True),
         _t("caesar3", encodings.caesar3_encode, encodings.caesar3_decode, "Caesar shift-by-3 cipher"),
+        _t("caesar5", encodings.caesar5_encode, encodings.caesar5_decode, "Caesar shift-by-5 cipher"),
+        _t("caesar13", encodings.caesar13_encode, encodings.caesar13_decode, "Caesar shift-by-13 cipher"),
         _t("artprompt", ascii_art.artprompt_encode, None, "ArtPrompt ASCII-art word masking (Jiang et al., ACL 2024)", lossy=True),
         _t("anagram", encodings.anagram_encode, encodings.anagram_decode, "Deterministic per-word letter scramble (not invertible)", lossy=True),
         _t("tokenbreak", encodings.tokenbreak_encode, encodings.tokenbreak_decode, "Prepend a benign char per token to break tokenizer boundaries", lossy=True),

--- a/wallbreaker/transforms/encodings.py
+++ b/wallbreaker/transforms/encodings.py
@@ -286,6 +286,22 @@ def caesar3_decode(text: str) -> str:
     return _caesar(text, -3)
 
 
+def caesar5_encode(text: str) -> str:
+    return _caesar(text, 5)
+
+
+def caesar5_decode(text: str) -> str:
+    return _caesar(text, -5)
+
+
+def caesar13_encode(text: str) -> str:
+    return _caesar(text, 13)
+
+
+def caesar13_decode(text: str) -> str:
+    return _caesar(text, -13)
+
+
 def _scramble_word(word: str) -> str:
     order = sorted(range(len(word)), key=lambda i: (word[i], i))
     return "".join(word[i] for i in order)


### PR DESCRIPTION
## Summary

Adds `caesar5` and `caesar13` transforms from the improvement roadmap (Phase 0: generalize `caesar(N)`), reusing the existing `_caesar` helper alongside `caesar3`.

## Changes

- `wallbreaker/transforms/encodings.py` — encode/decode for shift-by-5 and shift-by-13
- `wallbreaker/transforms/__init__.py` — register both as reversible, lossless ciphers
- `tests/test_transforms.py` — round-trip tests for each shift
- `wallbreaker/prompts.py` — list in agent transform doctrine

## Notes

- `caesar13` matches `rot13` on letters but provides an explicit named shift for transform chains.
- No new dependencies.

## Test plan

- [x] `pytest tests/test_transforms.py -q` (80 passed)