### PR TITLE
fix(packaging): install Pillow for built-in image tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "rich>=13.7",
     "mcp>=1.0",
     "python-dotenv>=1.0",
+    "pillow>=10.0",
 ]
 
 [project.urls]
@@ -38,7 +39,6 @@ dev = [
 barcodes = [
     "qrcode[pil]>=7.4",
     "python-barcode>=0.15",
-    "pillow>=10.0",
 ]
 stego = [
     "stegg[crypto]>=3.0",


### PR DESCRIPTION
## Problem

The built-in `build_typographic_image` tool and the local Pillow session-card fallback are registered and advertised in the default Wallbreaker install, but Pillow is only installed through the unrelated `barcodes` extra.

With the documented default install, invoking `build_typographic_image` fails with:

```text
Tool 'build_typographic_image' raised: ModuleNotFoundError: No module named 'PIL'
```

The full test suite also cannot collect from the documented `.[dev]` environment because `tests/test_typographic.py` imports Pillow unconditionally.

## Root cause

Pillow became a runtime dependency of core, always-registered image tools, but remained scoped to the optional barcode dependency group.

## Implementation

Move `pillow>=10.0` into the core project dependencies and remove the duplicate declaration from the `barcodes` extra. Barcode users still receive Pillow transitively through the base package, while default installations can run the built-in image features.

## Testing

- Built `wallbreaker-0.1.0-py3-none-any.whl`
- Installed that wheel with no extras in a brand-new virtual environment
- Executed `build_typographic_image` and verified that it emitted a valid PNG
- `pytest -q tests/test_typographic.py tests/test_session_card.py tests/test_dashboard.py tests/test_agent_profiles.py` — 62 passed, 1 skipped
- Corpus-independent suite — 1,012 passed, 27 skipped
- Dashboard frontend: `npm ci && npm run build`

The unfiltered suite in a fresh clone remains blocked by repository-external/gitignored ENI, ZetaLib, UltraBr3aks, and system-prompt corpora (39 failures and 7 errors after dependencies are installed). That pre-existing test-data reproducibility issue is unrelated to this packaging change and is not hidden by this PR.

## Risk

Low. This changes installation footprint by making Pillow available to all users, matching the default tool registry and documented fallback behavior. No APIs or output formats change.

## Backward compatibility

Fully backward compatible. Existing `wallbreaker[barcodes]` installs continue to include Pillow.

## Future improvements

The contributor test path should either bootstrap the external corpora or mark corpus-dependent tests so a fresh clone can produce an honest, reproducible suite result.
