### PR TITLE
fix(deps): pin mcp<2.0 — FastMCP removed in mcp 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "httpx[http2]>=0.27",
     "textual>=0.79",
     "rich>=13.7",
-    "mcp>=1.0",
+    "mcp>=1.0,<2.0",
     "python-dotenv>=1.0",
 ]
 


### PR DESCRIPTION
mcp 2.0.0 (released 2026-08-01) restructured the server API: mcp.server.fastmcp.FastMCP no longer exists (now MCPServer at mcp.server.mcpserver). This breaks wallbreaker_mcp, p4rs3lt0ngv3_mcp, tests/_stub_mcp_server.py, and any downstream MCP server code on fresh installs where pip resolves mcp>=1.0 to 2.0.0.

Pin to 1.x until a dedicated migration to the 2.0 API is done.

## What

`mcp` 2.0.0 (released ~2026-08-01) restructured the server API: `mcp.server.fastmcp.FastMCP` no longer exists — it's now `MCPServer` at `mcp.server.mcpserver`. The dep spec `mcp>=1.0` resolves to 2.0.0 on fresh installs, breaking:

- `wallbreaker_mcp/server.py` — `from mcp.server.fastmcp import FastMCP`
- `p4rs3lt0ngv3_mcp/server.py` — same import
- `tests/_stub_mcp_server.py` — same import

## Failures

14 test failures on fresh CI:
- 11× `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` in `test_wallbreaker_mcp.py`
- 3× empty tool registry in `test_mcp_bridge.py` (stub server can't start)

## Fix

One-line pin: `mcp>=1.0` → `mcp>=1.0,<2.0`. Migrating to the mcp 2.0 API is a separate effort.

## Verification

All 14 affected tests pass locally with `mcp==1.29.0` (latest 1.x).