### PR TITLE
fix(ci): install dev extras so pytest is available in datasets-refresh

### DIFF
--- a/.github/workflows/datasets-refresh.yml
+++ b/.github/workflows/datasets-refresh.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install -U pip
-          pip install -e .
+          pip install -e ".[dev]"
 
       - name: List dataset cache status
         run: wallbreaker datasets list


### PR DESCRIPTION
The weekly `datasets-refresh` workflow installs base deps only (`pip install -e .`) and then runs `python -m pytest`. Since pytest lives in the `dev` extra, every schedule hit fails at the unit-test step with `ModuleNotFoundError: No module named 'pytest'`.

Verified: fresh py3.11 venv, `pip install -e ".[dev]"` → all 22 tests in `tests/test_datasets.py`, `test_frr_scan.py`, `test_branding.py`, `test_relentless.py` pass.

One-line change:
```diff
-          pip install -e .
+          pip install -e ".[dev]"
```