### PR TITLE
fix(cli): restore unreachable corpus verify command and parsel verify alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased — WebUI V2 unified operator surface
 
+- Fixed `wallbreaker corpus verify [--update]` (and the `wallbreaker parsel verify`
+  alias) becoming unreachable when the PR #21 and PR #24 lines merged: the dispatch
+  and subparser were dropped from `cli.py` while `_run_corpus_verify` survived as
+  dead code. Load-time pin checks were unaffected; the interactive command works
+  again. Routing is now regression-tested (`tests/test_corpus_cli_routing.py`).
 - Added a shared typed capability catalog so TUI behavior is the canonical contract and
   every registered operation remains discoverable from V2.
 - Added server-owned queued executions with pause, resume, steering, attacker switching,

--- a/tests/test_corpus_cli_routing.py
+++ b/tests/test_corpus_cli_routing.py
@@ -1,0 +1,77 @@
+"""Regression tests: the `corpus verify` CLI routing must stay reachable.
+
+The dispatch was born in 53c9ca2 (roadmap-implementation TG3) and silently
+lost when the PR #21 and PR #24 lines merged in da21689 — _run_corpus_verify
+survived as dead code while nothing failed. These tests pin the routing so a
+future merge cannot strand the command again.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import wallbreaker.cli as cli
+from wallbreaker.cli import SUBCOMMANDS, _run_corpus_verify, build_sub_parser
+
+
+def test_corpus_in_subcommands():
+    assert "corpus" in SUBCOMMANDS
+
+
+def test_corpus_verify_parses():
+    args = build_sub_parser().parse_args(["corpus", "verify"])
+    assert args.command == "corpus"
+    assert args.corpus_action == "verify"
+    assert args.update is False
+
+
+def test_corpus_verify_parses_update_and_lock():
+    args = build_sub_parser().parse_args(
+        ["corpus", "verify", "--update", "--lock", "/tmp/other.lock.toml"]
+    )
+    assert args.update is True
+    assert args.lock == "/tmp/other.lock.toml"
+
+
+def test_parsel_verify_alias_parses():
+    args = build_sub_parser().parse_args(["parsel", "verify"])
+    assert args.command == "parsel"
+    assert args.parsel_action == "verify"
+
+
+def test_main_routes_corpus_verify(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    lock = tmp_path / "library.lock.toml"
+    lock.write_text("", encoding="utf-8")
+    called = {}
+
+    def fake_verify(args):
+        called["lock"] = args.lock
+        return 7
+
+    monkeypatch.setattr(cli, "_run_corpus_verify", fake_verify)
+    rc = cli.main(["corpus", "verify", "--lock", str(lock)])
+    assert rc == 7
+    assert called["lock"] == str(lock)
+
+
+def test_main_routes_parsel_verify_alias(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    called = {}
+
+    def fake_verify(args):
+        called["via"] = "parsel"
+        return 0
+
+    monkeypatch.setattr(cli, "_run_corpus_verify", fake_verify)
+    rc = cli.main(["parsel", "verify"])
+    assert rc == 0
+    assert called["via"] == "parsel"
+
+
+def test_main_routes_parsel_update_to_parsel_lib(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """The verify alias must not swallow the real parsel actions."""
+    monkeypatch.setattr(
+        "wallbreaker.tools.parsel_lib.run_parsel_cli", lambda args: 0
+    )
+    rc = cli.main(["parsel", "list"])
+    assert rc == 0

--- a/wallbreaker/cli.py
+++ b/wallbreaker/cli.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import subprocess
 import sys
+from pathlib import Path
 
 from dotenv import load_dotenv
 
@@ -168,7 +170,7 @@ def _add_endpoint_flags(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--api-key", help="API key literal (prefer --api-key-env)")
 
 
-SUBCOMMANDS = ("lib", "parsel", "eni", "transform", "findings", "report", "export", "check", "regrade", "baseline", "dashboard")
+SUBCOMMANDS = ("lib", "parsel", "eni", "transform", "findings", "report", "export", "check", "regrade", "baseline", "dashboard", "corpus")
 
 
 def build_main_parser() -> argparse.ArgumentParser:
@@ -244,7 +246,7 @@ def build_sub_parser() -> argparse.ArgumentParser:
     parsel = sub.add_parser(
         "parsel", help="Manage the P4RS3LT0NGV3 transform library (MCP server backend)"
     )
-    parsel.add_argument("parsel_action", choices=["update", "list", "path"])
+    parsel.add_argument("parsel_action", choices=["update", "list", "path", "verify"])
 
     eni = sub.add_parser("eni", help="Browse the ENI persona-jailbreak collection")
     eni.add_argument("eni_action", choices=["list", "update", "path"])
@@ -304,6 +306,19 @@ def build_sub_parser() -> argparse.ArgumentParser:
         "--allow-network", action="store_true",
         help="Acknowledge the risk of exposing this unauthenticated single-operator dashboard",
     )
+
+    corpus = sub.add_parser("corpus", help="Manage corpus integrity pins (library.lock.toml)")
+    corpus_sub = corpus.add_subparsers(dest="corpus_action", required=True)
+    cv = corpus_sub.add_parser(
+        "verify",
+        help="Check corpus SHAs against library.lock.toml; non-zero exit on UNRESOLVED or DRIFT",
+    )
+    cv.add_argument(
+        "--update",
+        action="store_true",
+        help="Attempt to resolve actual HEAD SHAs via git ls-remote and update the lock file",
+    )
+    cv.add_argument("--lock", default=None, help="Path to library.lock.toml (default: repo root)")
 
     return parser
 
@@ -412,7 +427,11 @@ def main(argv: list[str] | None = None) -> int:
             from .tools.eni import run_eni_cli
 
             return run_eni_cli(args)
+        if args.command == "corpus":
+            return _run_corpus_verify(args)
         if args.command == "parsel":
+            if getattr(args, "parsel_action", None) == "verify":
+                return _run_corpus_verify(args)
             from .tools.parsel_lib import run_parsel_cli
 
             return run_parsel_cli(args)


### PR DESCRIPTION
## Problem

`wallbreaker corpus verify [--update]` — the interactive surface for the corpus integrity pins in `library.lock.toml` — is defined but **unreachable** on `main`. Running it today does not verify anything: `corpus` is not in the CLI's subcommand list, so the word is consumed as a one-shot prompt and the TUI starts.

This also breaks the tool's own guidance: `wallbreaker/tools/parsel_engine.py:570` tells users to run `wallbreaker corpus verify --update` when a corpus SHA is unpinned — a command that cannot run.

## Root cause

The command was added in `53c9ca2` (roadmap-implementation, TG3): `corpus` in `SUBCOMMANDS`, a `corpus verify` subparser, and its dispatch line. When the PR #21 line merged with the PR #24 (Daedalus) line in `da21689`, the `cli.py` conflict resolved to the PR #24 side, which had forked from main *before* `53c9ca2` and never carried the corpus dispatch. Result: `_run_corpus_verify()` and `_resolve_lock_path()` survived as definitions, but their routing, the subparser block, and two imports (`subprocess`, `pathlib.Path`) were dropped.

## Fix

Restores exactly what the merge dropped (verified against `f086481`'s tree):

- `corpus` back in `SUBCOMMANDS`
- the `corpus verify` subparser (`--update`, `--lock`) in `build_sub_parser()`
- dispatch: `corpus` → `_run_corpus_verify(args)`, plus the `parsel verify` alias (`verify` added to `parsel_action` choices + `getattr` routing, matching the function's documented alias)
- re-add `import subprocess` and `from pathlib import Path`

The load-time pin check (`load_corpus_with_pin_check`, fail-closed on mismatch) was always intact and is untouched — this only restores the interactive pin/verify surface.

## Regression tests

New `tests/test_corpus_cli_routing.py` (7 tests) pins the routing so a future merge cannot silently strand the command again:

- parser-level: `corpus verify` parses (`corpus_action == "verify"`), with `--update`/`--lock`
- `"corpus" in SUBCOMMANDS`
- `main()` routing: `_run_corpus_verify` invoked with the parsed args, return code propagated
- `parsel verify` alias parses and routes to the same function
- the alias does not swallow the real `parsel` actions (`parsel list` still routes to `run_parsel_cli`)

Plus a CHANGELOG entry under Unreleased.

## Test plan

- `python -m py_compile wallbreaker/cli.py` — clean
- `python -m pytest tests/test_corpus_cli_routing.py tests/test_tg3_corpus.py tests/test_cli_one_shot.py -q` → 15 passed
- `wallbreaker corpus verify --help` / `wallbreaker corpus verify` / `wallbreaker corpus verify --update` — work as documented (resolves UNRESOLVED pins via `git ls-remote`; exits non-zero on MISSING/UNRESOLVED as designed)
- `wallbreaker parsel verify` — alias routes to the same function
- all 12 subcommands parse `--help` cleanly

Note: an earlier iteration of this branch carried two `session_card` hardening commits; they were split out to keep this PR focused on the CLI fix.